### PR TITLE
op.sh, doc, and line-endings

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,6 +1,14 @@
-# Store all text files with LF line endings, and do not modify on checkout
-* text eol=lf
+* text=auto
 
-# Except make sure .sh and .bat files use CRLF on Windows
-*.sh text eol=crlf
+*.sh text eol=lf
+
 *.bat text eol=crlf
+*.cmd text eol=crlf
+*.ps1 text eol=crlf
+
+*.png binary
+*.jpg binary
+*.jpeg binary
+*.gif binary
+*.bmp binary
+*.tiff binary

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -10,4 +10,6 @@ LiveImport
     :caption: Contents:
 
     api
-
+    installation
+    issues
+    tips

--- a/doc/installation.rst
+++ b/doc/installation.rst
@@ -1,0 +1,19 @@
+
+Installation
+------------
+
+You can install LiveImport from PyPI with
+
+.. code:: console
+
+    $ pip install liveimport
+
+You can also clone the repo and install it directly.
+
+.. code:: console
+
+    $ git clone https://github.com/escreven/liveimport.git
+    $ cd liveimport
+    $ pip install .
+
+LiveImport requires Python 3.10 or greater and IPython 7.16.1 or greater.

--- a/doc/issues.rst
+++ b/doc/issues.rst
@@ -1,0 +1,5 @@
+Questions or Issues
+-------------------
+
+If you have any questions or encounter any issues, please submit them on
+`GitHub <https://github.com/escreven/liveimport/issues>`_.

--- a/doc/tips.rst
+++ b/doc/tips.rst
@@ -1,0 +1,36 @@
+
+Tips
+----
+
+While LiveImport does not require executed and registered import statements to
+be identical, the results of reloading may be surprising if they are not.
+Since the ``%%liveimport`` cell magic both executes and registers import
+statements, it naturally ensures that identity.  
+
+If you choose to use `register()`:func: in a notebook instead of relying on
+cell magic or you are using LiveImport outside a notbook, the recommended
+practice is to place all imports for modules to be tracked together followed
+immediately by a `register()`:func: call with the same import statement text
+written as a multiline string.  That way maintaining identical executed and
+registered import statements is simple.
+
+When using either ``%%liveimport`` magic or `register()`:func: calls in a
+notebook, it's best if the first use in the notebook includes option
+``--clear`` or ``clear=True`` respectively.  If it does, rerunning the notebook
+makes LiveImport registrations consistent with what appears in the notebook.  
+
+Modules sometimes take action when they load that should be performed
+differently or not at all when they reload.  Here is one approach:
+
+    .. code:: python
+    
+        try:
+            _did_initial_load    #type:ignore
+            print("Reloading module")
+        except NameError:
+            _did_initial_load = True
+            print("First load of module")
+    
+The code above should be at the top level of your module.  Because
+``did_initial_load`` is undefined on the first load, the exception handling
+code runs.  On reloads, the ``try`` primary path runs normally.

--- a/op.sh
+++ b/op.sh
@@ -56,6 +56,9 @@ require_one_built_version() {
 #
 # Succeed iff twine check succeeds for the built distribution files.
 #
+# NOTE: There is currently a bug in twine or setuptools that causes this to
+# spuriously fail on Mac with an error message related to license_file.
+#
 
 require_good_build() {
     $PYTHON -m twine check dist/* || fail "Twine check failed"

--- a/op.sh
+++ b/op.sh
@@ -99,7 +99,7 @@ upload_dist() {
         echo "Upload canceled."
         exit 1
     fi
-    # $PYTHON -m twine upload --repository "$repo" dist/*
+    $PYTHON -m twine upload --repository "$repo" dist/*
 }
 
 #

--- a/op.sh
+++ b/op.sh
@@ -62,8 +62,8 @@ require_good_build() {
 }
 
 #
-# Succeed iff the local repo is on branch main, is up to date with the remote,
-# and has no unstaged or uncommitted changes, and is not ahead of remote.
+# Succeed iff the local repo is on branch main, is synced with remote (neither
+# ahead nor behind), and has no unstaged or uncommitted changes.
 #
 
 require_git_tip() {
@@ -74,7 +74,7 @@ require_git_tip() {
 
     git fetch origin
     local_status=$(git status -uno | grep "Your branch is up to date")
-    [ -n "$local_status" ] || fail "Local is not up to date with remote"
+    [ -n "$local_status" ] || fail "Local is not synced with remote"
 
     git diff --quiet || fail "There are unstaged changes"
 

--- a/op.sh
+++ b/op.sh
@@ -1,0 +1,141 @@
+#!/bin/sh
+
+#
+# op.sh - A build and deployment script for LiveImport
+#
+
+set -e
+
+PYTHON=python3
+if uname -s | grep -q CYGWIN; then
+    PYTHON=py
+fi
+
+fail() {
+    echo "FAILED: $@" >&2
+    exit 1
+}
+
+require_consistent_version() {
+
+    pyproject_version=$(\
+        sed -n 's/^version = "\([^"][^"]*\)"/\1/p' pyproject.toml)
+
+    [ -z "$pyproject_version" ] \
+        && fail "Could not find version in pyproject.toml"
+
+    python_version=$(\
+        sed -n 's/^__version__ = "\([^"][^"]*\)"/\1/p' src/liveimport.py)
+
+    [ -z "$python_version" ] \
+        && fail "Could not find version in liveimport.py"
+        
+    [ "$pyproject_version" = "$python_version" ] \
+        || fail "Version mismatch: pyproject.toml ($pyproject_version)" \
+                " != src/liveimport.py ($python_version)"
+
+    echo $python_version
+}
+
+require_one_built_version() {
+    [ -d dist ] || fail "Distribution directory dist/ does not exist"
+    count=$(ls dist/*.whl 2>/dev/null | wc -l)
+	[ $count -eq 1 ] || fail "Expected one built version; found" $count
+}
+
+require_good_build() {
+    $PYTHON -m twine check dist/* || fail "Twine check failed"
+}
+
+require_git_tip() {
+
+    current_branch=$(git rev-parse --abbrev-ref HEAD)
+    [ "$current_branch" = "main" ] \
+        || fail "On branch $current_branch, not main"
+
+    git fetch origin
+    local_status=$(git status -uno | grep "Your branch is up to date")
+    [ -n "$local_status" ] || fail "Local is not up to date with remote"
+
+    git diff --quiet || fail "There are unstaged changes"
+
+    git diff --cached --quiet || fail "There are uncommitted changes"
+}
+
+upload_dist() {
+    require_one_built_version
+    require_good_build
+    require_git_tip
+    name="$1"
+    repo="$2"
+    echo
+    echo ">>>> Uploading to $name cannot be undone."
+    read -p ">>>> Type $name to confirm: " confirm
+    echo
+    if [ "$confirm" != "$name" ]; then
+        echo "Upload canceled."
+        exit 1
+    fi
+    # $PYTHON -m twine upload --repository "$repo" dist/*
+}
+
+usage() {
+    echo "Usage: $0 ACTION"
+    echo
+    echo "Where ACTION is one of"
+    echo 
+    echo "    build-doc           Build the documentation"
+    echo "    build-dist          Build wheel and sdist files in dist/"
+    echo "    check-dist          Verify the distribution files"
+    echo "    check-tip           Verify local repo is at tip"
+    echo "    deploy-to-testpypi  Upload distribution files to TestPyPI"
+    echo "    deploy-to-pypi      Upload distribution files to PyPI"
+    echo "    clean-doc           Delete documentation"
+    echo "    clean-dist          Delete distribution files"
+    echo "    clean               Delete both doc and distribution files"
+    echo 
+    echo "The deployment actions require user confirmation."
+    echo
+    exit 1
+}
+
+action="$1"
+
+case "$action" in
+    build-doc)
+        make -C doc html
+        ;;
+    build-dist)
+        version=$(require_consistent_version)
+        echo "Building version $version"
+        $PYTHON -m build
+        ;;
+    check-dist)
+        require_one_built_version
+        require_good_build
+        ;;
+    check-tip)
+        require_git_tip
+        ;;
+    deploy-to-testpypi)
+        upload_dist TestPyPI testpypi
+        ;;
+    deploy-to-pypi)
+        upload_dist PyPI pypi
+        ;;
+    clean-doc)
+        make -C doc clean
+        ;;
+    clean-dist)
+        rm -rf dist/*
+        ;;
+    clean)
+        make -C doc clean
+        rm -rf dist/*
+        ;;
+    *)
+        usage
+        ;;
+esac
+
+echo "Done."

--- a/op.sh
+++ b/op.sh
@@ -16,6 +16,11 @@ fail() {
     exit 1
 }
 
+#
+# Succeed iff all version markers in project are identical (currently in
+# pyproject.toml and liveimport.py.)
+#
+
 require_consistent_version() {
 
     pyproject_version=$(\
@@ -37,15 +42,29 @@ require_consistent_version() {
     echo $python_version
 }
 
+#
+# Succeed iff there is exactly built version, which we determine by counting
+# wheel files in dist/.
+#
+
 require_one_built_version() {
     [ -d dist ] || fail "Distribution directory dist/ does not exist"
     count=$(ls dist/*.whl 2>/dev/null | wc -l)
 	[ $count -eq 1 ] || fail "Expected one built version; found" $count
 }
 
+#
+# Succeed iff twine check succeeds for the built distribution files.
+#
+
 require_good_build() {
     $PYTHON -m twine check dist/* || fail "Twine check failed"
 }
+
+#
+# Succeed iff the local repo is on branch main, is up to date with the remote,
+# and has no unstaged or uncommitted changes, and is not ahead of remote.
+#
 
 require_git_tip() {
 
@@ -61,6 +80,10 @@ require_git_tip() {
 
     git diff --cached --quiet || fail "There are uncommitted changes"
 }
+
+#
+# Update to TestPyPI or PyPI.  Requires a user confirmation.
+#
 
 upload_dist() {
     require_one_built_version
@@ -78,6 +101,10 @@ upload_dist() {
     fi
     # $PYTHON -m twine upload --repository "$repo" dist/*
 }
+
+#
+# Print usage and exit.
+#
 
 usage() {
     echo "Usage: $0 ACTION"
@@ -98,6 +125,10 @@ usage() {
     echo
     exit 1
 }
+
+#
+# Dispatch
+#
 
 action="$1"
 

--- a/op.sh
+++ b/op.sh
@@ -82,6 +82,24 @@ require_git_tip() {
 }
 
 #
+# Build the wheel and sdist files.  build_dist removes the left-over egg-info
+# directory.  Hopefully build will stop leaving behind one day.
+#
+
+build_dist() {
+
+    version=$(require_consistent_version)
+
+    echo "Building version $version"
+    $PYTHON -m build
+
+    if [ -d src/liveimport.egg-info ]; then
+        echo "Deleting egg-info"
+        /bin/rm -r -f src/liveimport.egg-info
+    fi
+}
+
+#
 # Update to TestPyPI or PyPI.  
 #
 # We only allow uploads if the repo is in sync with the tip of main.  In some
@@ -145,9 +163,7 @@ case "$action" in
         make -C doc html
         ;;
     build-dist)
-        version=$(require_consistent_version)
-        echo "Building version $version"
-        $PYTHON -m build
+        build_dist
         ;;
     check-dist)
         require_one_built_version

--- a/op.sh
+++ b/op.sh
@@ -82,7 +82,15 @@ require_git_tip() {
 }
 
 #
-# Update to TestPyPI or PyPI.  Requires a user confirmation.
+# Update to TestPyPI or PyPI.  
+#
+# We only allow uploads if the repo is in sync with the tip of main.  In some
+# ways this is the wrong place to check, since the build could have been
+# performed in a branch.  But for testing, we want to allow building in a
+# branch, so we check here.
+#
+# Because uploading to [Test]PyPI cannot be undone, upload_dist requires user
+# confirmation.
 #
 
 upload_dist() {

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "liveimport"
-version = "0.9.1"
+version = "0.9.2dev1"
 description = "Automatically reload modified Python modules in notebooks and scripts."
 readme = "README.md"
 authors = [{ name = "Edward Screven" }]

--- a/src/liveimport.py
+++ b/src/liveimport.py
@@ -43,41 +43,20 @@ Modules referenced by registered import statements are called tracked modules.
 The process of bringing registered imports up to date by reloading tracked
 modules and updating symbols is called syncing.
 
-LiveImport analyzes top-level import [#f1]_ dependencies between tracked
-modules to ensure reloading is consistent with those dependencies.  Suppose
-``simulator`` imports ``symcode``.  Then, if you modify ``symcode.py``,
-LiveImport reloads ``simulator`` after it reloads ``symcode`` even if
-``simulator.py`` has not changed.  If you do modify both, LiveImport takes care
-to reload ``symcode`` first.
-
-Recommended Practice
---------------------
-
-While LiveImport does not require executed and registered import statements to
-be identical, the results of reloading may be surprising if they are not.
-
-The ``clear=True`` option shown in the example above causes `register()`:func:
-to discard all prior import registrations targeting the given namespace.  So,
-if you wanted to stop tracking modifications to ``symcode.py``, you could
-simply delete ``import symcode`` from the `register()`:func: `importstmts`
-argument and rerun the cell.
-
-Considering the previous two paragraphs, the recommended practice is to place
-all imports for modules to be tracked together in an initial cell followed
-immediately by a `register()`:func: call with ``clear=True`` and the same
-import statement text written as a multiline string.  That way maintaining
-identical executed and registered import statements is simple, and rerunning
-the notebook makes registrations consistent with what appears in the notebook.
-The example follows this form.
+The ``clear=True`` option used above causes `register()`:func: to discard all
+prior import registrations targeting the given namespace.  So, if you wanted to
+stop tracking modifications to ``symcode.py``, you could simply delete ``import
+symcode`` from the `register()`:func: `importstmts` argument and rerun the
+cell.
 
 Cell Magic
 ----------
 
-As an alternative, LiveImport defines a cell magic ``%%liveimport`` which both
-executes the cell content and registers every top-level import statement.
-Option ``--clear`` of ``%%liveimport`` has the same effect as ``clear=True``
-with `register()`:func:.  So, you could split the example cell above into two,
-making the second
+As an alternative to `register()`:func:, LiveImport defines a cell magic
+``%%liveimport`` which both executes the cell content and registers every
+top-level [#f1]_ import statement.  Option ``--clear`` of ``%%liveimport`` has
+the same effect as ``clear=True`` with `register()`:func:.  So, you could split
+the example cell above into two, making the second
 
   .. code:: python
 
@@ -112,6 +91,16 @@ which is followed by cell
       from printmath import print_math, print_equations as print_eq
       from simulator import *
 
+Dependency Analysis
+-------------------
+
+LiveImport analyzes top-level import dependencies between tracked
+modules to ensure reloading is consistent with those dependencies.  Suppose
+``simulator`` imports ``symcode``.  Then, if you modify ``symcode.py``,
+LiveImport reloads ``simulator`` after it reloads ``symcode`` even if
+``simulator.py`` has not changed.  If you do modify both, LiveImport takes care
+to reload ``symcode`` first.
+
 Reload Reports
 --------------
 
@@ -126,8 +115,8 @@ automatically reloads modules in a notebook, something like
 You can disable these reports by calling
 `auto_sync(report=False)<auto_sync>`:func:.
 
-Additional Information
-----------------------
+Outside of Notebooks
+--------------------
 
 You can use LiveImport outside of notebook environments, but in that case,
 there is no automatic syncing, so you must call `sync()`:func: explicitly.  You
@@ -135,24 +124,11 @@ can also disable automatic syncing in a notebook by calling
 `auto_sync(enabled=False) <auto_sync>`:func: and rely on explicit syncing
 instead.
 
-Modules sometimes take action when they load that should be performed
-differently or not at all when they reload.  Here is one approach:
-
-  .. code:: python
-
-      try:
-          _did_initial_load    #type:ignore
-          print("Reloading module")
-      except NameError:
-          _did_initial_load = True
-          print("First load of module")
-
 .. [#f1] A "top-level import" is any ``import ...`` or ``from ... import ...``
    statement in Python source that is not nested within another Python
    construct such as an ``if`` or ``try`` statement.
-
 """
-__version__ = "0.9.1"
+__version__ = "0.9.2dev1"
 
 import math
 import re


### PR DESCRIPTION
Added a `op.sh` build and deploy script at the root.

Restructured the documentation.

Fixed line-endings problem.
