### PR TITLE
Preparing to release

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -182,3 +182,6 @@ cython_debug/
 # Ignored version of op.sh that makes it easier to test op.sh changes related
 # to requring a clean, synchronized tree.
 private-op.sh
+
+#
+.DS_Store

--- a/README.md
+++ b/README.md
@@ -1,85 +1,53 @@
-Automatically reload modified Python modules in notebooks and scripts.
-
 ## Overview
 
-LiveImport eliminates the need to restart a notebook's Python server to
-reimport code under development in external files.  Suppose you are maintaining
-symbolic math code in ``symcode.py``, LaTeX formatting utilities in
-``printmath.py``, and a simulator in ``simulator.py``.  In the first cell of a
-notebook, you might write
+LiveImport reliably and automatically reloads Python modules in Jupyter
+notebooks.  Unlike IPython's autoreload extension, LiveImport reloads are
+well-defined, deterministic operations that follow the semantics of a
+developer's import statements exactly.  It maintains consistency between
+modules by automatically reloading dependent modules as needed, ensuring
+up-to-date references across a notebook and its modules.
+
+LiveImport is designed for developers who interactively build Jupyter notebooks
+together with external Python code, and who want predictable reloading with
+minimal mystery.
+
+Given a cell like
 
 ```python
-import liveimport
-import numpy as np
-import matplotlib.pyplot as plot
-```
-and in the second
-```python
-%%liveimport --clear
-import symcode
-from printmath import print_math, print_equations as print_eq
-from simulator import *
+%%liveimport
+from common import *
+from nets import ConvNet, ResidualNet as ResNet
+import hyperparam as hp
 ```
 
-When the ``%%liveimport`` cell is run, LiveImport executes and registers the
-import statements.  Thereafter, whenever you run cells, LiveImport will reload
-any of ``symcode``, ``printmath``, and ``simulator`` that have changed since
-registration or their last reload.  LiveImport deems a module changed when its
-source file modification time changes.
+LiveImport will execute the import statements, then automatically reload
+``common``, ``nets``, or ``hyperparam`` whenever their source files change.
+When LiveImport reloads, it will rebind symbols in the notebook as described by
+the import statements.  If ``nets`` imports from ``hyperparam``, then when
+``hyperparam`` is modified, LiveImport will automatically reload ``nets`` after
+``hyperparam``.
 
-LiveImport also updates imported module symbols.  For example, if you modify
-``printmath.py``, LiveImport will reload ``printmath`` and bind ``print_math``
-and ``print_eq`` in the global namespace to the new definitions.  Similarly, if
-you update ``simulator.py``, LiveImport will create or update bindings for
-every public symbol in ``simulator`` — that is, every symbol defined in the
-module that does not start with ``_``, unless there is an ``__all__`` property
-defined for the module, in which case it acts on only those symbols, just like
-``from simulator import *``.
-
-Modules referenced by registered import statements are called tracked modules.
-LiveImport analyzes top-level import dependencies between tracked modules to
-ensure reloading is consistent with those dependencies.  Suppose ``simulator``
-imports ``symcode``.  Then, if you modify ``symcode.py``, LiveImport reloads
-``simulator`` after it reloads ``symcode`` even if ``simulator.py`` has not
-changed.  If you do modify both, LiveImport takes care to reload ``symcode``
-first.
-
-## Hidden Cell Magic
-
-Unfortunately, Visual Studio Code and possibly other environments do not
-analyze magic cell content, making ``%%liveimport`` use awkward.  However,
-LiveImport includes a workaround: calling `hidden_cell_magic(True)` causes
-``#_%%liveimport`` lines at the beginning of cells to act just like
-``%%liveimport`` when the cell is run, and since ``#_%%liveimport`` is a Python
-comment, Visual Studio Code and other environments do analyze the content.
-
-A complete hidden cell magic example equivalent to the first begins with cell
+To make the cell above transparent to IDEs like Visual Studio Code, you can
+hide the cell magic:
 
 ```python
-import liveimport
-import numpy as np
-import matplotlib.pyplot as plot
-liveimport.hidden_cell_magic(True)
-```
-followed by cell
-```python
-#_%%liveimport --clear
-import symcode
-from printmath import print_math, print_equations as print_eq
-from simulator import *
+#_%%liveimport
+from common import *
+from nets import ConvNet, ResidualNet as ResNet
+import hyperparam as hp
 ```
 
-## Programmatic Interface
+Hidden cell magic is a user experience feature tailored for modern notebook
+development.  Others include protection against reloading in the middle of
+multi-cell runs and optional reload notification.
 
-The LiveImport API includes programmatic registration, explicit syncing, and
-configuration of LiveImport's notification and automatic syncing behavior.  In
-addition to offering fine control within a notebook, the API enables
-applications to use LiveImport outside of notebook environment.
+If you currently use autoreload, you might consider [comparing LiveImport
+to autoreload](comparison/Comparison.md).
 
 ## Documentation
 
-For more details including an API reference see
-[liveimport.readthedocs.io](https://liveimport.readthedocs.io).
+See [liveimport.readthedocs.io](https://liveimport.readthedocs.io) for a user
+guide and an API reference.
 
 ## Installation
 

--- a/comparison/Comparison.md
+++ b/comparison/Comparison.md
@@ -1,0 +1,76 @@
+## Comparison to Autoreload
+
+While the IPython autoreload extension is useful and widely known, LiveImport
+is different from autoreload in ways that may make it a better fit for many
+notebook workflows.
+
+### Consistency
+
+The overriding philosophy of LiveImport is that reloading must be a
+well-defined, deterministic operation that follows the semantics of a
+developer's import statements exactly.  It uses dependency awareness to
+maintain consistency and makes no guesses.  It does not mutate existing
+objects, and instead rebinds names to fresh definitions.
+
+Autoreload attempts to preserve existing object references by patching function
+and class definitions in place, and uses name-based heuristics for rebinding.
+It does not provide import statement equivalent semantics, and it accepts that
+partial updates and inconsistencies will occur.
+
+If your notebook includes the import
+
+```python
+from netplot import baseline_color, learning_rate_color as lrc, plot_training
+```
+
+LiveImport will rebind ``baseline_color``, ``lrc`` and ``plot_training`` and
+nothing else when it reloads ``netplot``.  If ``plot_training`` is a function
+and the colors are values (perhaps strings), autoreload patches
+``plot_training``, does not rebind ``baseline_color`` in its explicit mode,
+and never rebinds ``lrc`` in any mode.  Moreover, if both ``netplot`` and your
+notebook define ``trace_mode`` variables, autoreload will overwrite your
+notebook's ``trace_mode`` variable when it reloads ``netplot`` in complete
+mode.
+
+Autoreload's approach can also lead to stale references between modules.  For
+example, if ``orchestrate.py`` imports from ``netplot`` in the same way as
+above, plots created by ``orchestrate.train()`` would not use updated colors.
+In contrast, LiveImport would reload ``orchestrate`` after ``netplot`` changed
+in order to update ``orchestrate``'s references to ``netplot``.
+
+One advantage of autoreload's patching approach is that an existing class
+instance immediately reflects changes made to its methods.  While that can be
+useful, it is hard to always get right as a user, since new versions of methods
+must be made to work correctly with existing instance state.  LiveImport
+doesn't patch; existing instances keep their old method definitions.
+
+### User Experience
+
+LiveImport avoids reloading between cell executions of multi-cell runs.  That
+way, your running notebook codebase is frozen, even if you happen to modify a
+file during a run.  Autoreload checks for modified files before every cell
+execution, meaning function and class definitions can change in the middle of a
+run.
+
+LiveImport's hidden cell magic allows you to take full advantage of your IDE in
+code cells.  With autoreload, unless your IDE has special support for
+``%aimport`` line magic (Visual Studio Code does not), using autoreload's
+explicit mode makes your coding less productive.
+
+By default, LiveImport notifies you when it reloads modules by displaying
+Markdown blocks such as
+
+```console
+    Reloaded symcode modified 36 seconds ago
+    Reloaded simulator because symcode reloaded
+```
+
+While you can disable notifications, they help avoid wasting time when
+unexpected reloads happen, or expected reloads do not.  Autoreload is
+silent.
+
+### Explore
+
+[This directory](.) contains small notebooks and modules
+along with a step-by-step README if you would like to investigate
+the differences between LiveImport and autoreload yourself.

--- a/comparison/README.md
+++ b/comparison/README.md
@@ -1,0 +1,320 @@
+
+### Introduction
+
+The files in this directory are used to compare the behaviors of LiveImport and
+the IPython autoreload extension.
+
+Notebooks `using-liveimport.ipynb` and `using-autoreload.ipynb` are similar,
+differing only in which mechanism is used to automatically reload.
+
+Files `alpha.py`, `beta.py`, `gamma.py`, `delta.py`, and `epsilon.py` are
+modules to be imported and automatically reloaded into the notebooks.  They
+each include a `<module>_tag` global variable to be manually updated to
+generate reloads (incrementing is recommended).  Those tags plus other
+variables, functions, and classes in the modules are used to observe the
+outcome of reloads.
+
+The notebooks have four sections
+
+1. **Setup** — Configuring automatic imports and other initialization
+
+2. **Print** — A cell that prints the module tags and other values, used
+   to see the effect of reloading.
+
+3. **Existing Instance** — Cells for experimenting with an existing class
+   instance.
+
+4. **Multi-cell Run** — A pair of cells meant to be run together.
+
+### Preparation
+
+The autoreload extension has four operating modes: `off`, `explicit`, `all`,
+and `complete`.  We will begin the comparison with autoreload in `explicit`
+mode, then discuss `all` and `complete` further down.
+
+Open `using-autoreload.ipynb` and make sure you see
+
+```python
+%autoreload explicit
+```
+
+If instead you see
+
+```python
+%autoreload complete  # ... or off, or all
+```
+
+change it to `explicit`.
+
+Also, open `epsilon.py` and make sure the lines of the `__init__()` and
+`__str__()` methods of class `Epsilon` referencing field `self.another` or
+including the word "CHANGED" are commented out.
+
+Ensuring all tag values in `alpha.py`, `beta.py`, etc. are `1` is recommended,
+but not required.  (It makes reloading effects easier to follow.)
+
+### Recommended Comparison Steps
+
+#### Step 1:
+
+Open both `using-liveimport.ipynb` and `using-autoreload.ipynb`.  If they are
+already open, and you've already run cells, restart the kernels.
+
+If you are using VSCode or a similar IDE, see if the IDE understands that
+module `alpha` is imported.  VSCode understands `alpha` is imported in the
+LiveImport notebook; when you mouse over a reference to `alpha_tag`, VSCode
+indicates it's a variable defined in `alpha` with type `int`.  VSCode doesn't
+understand that `alpha` is imported in the autoreload notebook.  That's because
+the LiveImport magic is hidden (see the `#_%%liveimport --clear` line), while
+autoreload magic is not.  Other IDEs may differ.
+
+#### Step 2:
+
+Run all cells in both notebooks.  (It will take about 10 seconds because the
+**Multi-cell Run** section includes a `sleep()` call used later.)  You should
+see the initial tag values in the **Print** section of both notebooks.
+
+#### Step 3:
+
+Increment `alpha_tag` in `alpha.py`. Remember to save!  Rerun the **Print
+Tags** cell in both notebooks.  While the new `alpha_tag` values are now shown
+in the cell output of both notebooks, there are important differences.
+
+First, LiveImport notified you that it reloaded modules, displaying a Markdown
+block like
+
+```console
+Reloaded alpha modified 22 seconds ago
+Reloaded beta because alpha reloaded
+```
+
+The autoreload notebook included no such notification.  When you are working on
+a notebook, being suprised by a reload — or being surprised by a *non*-reload —
+can waste time.  If you don't like LiveImport's notification blocks, you can
+turn them off by calling `liveimport.auto_sync(report=False)`.
+
+Second, LiveImport didn't just reload `alpha`, it reloaded `beta`.  Why?
+Because `beta` imports `alpha_tag`, `alpha_fn()`, and `Alpha` from `alpha`.
+LiveImport tracks top-level dependencies between modules it imports,
+automatically reloading dependent modules as well as modified modules.
+
+Reloading `beta` refreshes the references from `beta` to `alpha`.  You can see
+evidence of this in LiveImport's **Print** output: the `beta.alpha_tag`, and
+the output of `alpha_fn()`, and `Alpha()` called and constructed from `beta`
+all show `alpha`'s new tag value.
+
+Autoreload takes a different approach.  When it reloads, it patches the old
+in-memory definitions of functions and classes to make them look like the new
+definition.  That way existing references to those functions and classes remain
+valid.  However, this strategy is incomplete.
+
+Examine the autoreload notebook **Print** cell output. While the output of
+`alpha_fn()`, and `Alpha()` called and constructed from `beta` show `alpha`'s
+new tag value, `beta.alpha_tag` does not.  There is now an inconsistency
+between the in-memory versions of `alpha` and `beta` that could lead to hard to
+understand behavior.
+
+#### Step 4:
+
+Examine the **Setup** section of the LiveImport notebook.  It's divided into
+two cells, the second starting with the comment `#_%%liveimport --clear`.  That
+marks the cell as a LiveImport hidden magic cell, enabling both LiveImport and
+your IDE to process the cell contents correctly.  You don't have to use hidden
+cell magic; normal cell magic `%%liveimport --clear` works too.
+
+Now examine the **Setup** section of the autoreload notebook.  Only one cell is
+needed because autoreload uses line magic.  While that's nice, there are two
+issues
+
+1. The line magic isn't hidden, and (as discussed in Step 1), some
+IDEs don't understand what `%aimport` means.
+
+2. `%aimport` arguments are module names, not general Python import statements.
+`%aimport` does not, for example, support `from <module> import ...`.
+
+We try to work around issue (2) by having both the import statement we want and
+an `%aimport` mentioning that same module.  In the LiveImport notebook we don't
+have to do that: LiveImport supports every legal Python import statement,
+including relative imports.
+
+Let's test the autoreload workaround.  Increment `gamma_tag` in `gamma.py`.
+That will also update a variable `gamma_second` in `gamma.py`.  Recall the
+relevant import statement
+
+```python
+from gamma import gamma_tag, gamma_second as gs, gamma_fn, Gamma
+```
+
+What we hope is that on reload the notebooks see updated `gamma_tag` and `gs`
+values, and `gamma_fn()` and `Gamma` called and constructed from the notebook
+show the new values.  Run the **Print** cell in both notebooks to see what
+happens.
+
+LiveImport correctly updates `gamma_tag`, `gs`, `gamma_fn`, and `Gamma`.
+
+Autoload does not update `gamma_tag` or `gs`.  That's because in `explicit`
+mode, autoreload does not rebind imported variables. Mode `complete` does
+update bindings, but inexactly.  In this case, it would change the binding of
+`gamma_tag` but not the binding of `gs`.  More on this inexactness later.
+
+Autoreload does patch the definitions of `gamma_fn()` and `Gamma`, but does
+so incorrectly.  The relevant output is
+
+```console
+Notebook calls gamma_fn()=gamma_fn: tag=2; second=1
+Notebook constructs Gamma<tag=2; second=1>
+[gamma.gamma_second=1]
+```
+
+The tag value is correct, but the second value, which should be a copy of the
+tag, is not.  The bracketed output shows the value of `gamma_second` in
+`gamma`'s module dictionary.  The autoreload patching machinery has discarded
+the change to gamma_second.  (However, the change is kept `complete` mode.)
+
+#### Step 5:
+
+One advantage of autoreload's patching approach is that updates can change the
+definition of existing class instances.  Examine the output of the second
+**Existing Instance** cell in both notebooks.  You should see something like
+
+```console
+an_epsilon=Epsilon<tag=1>
+```
+
+Notice the second cell prints an existing instance of `Epsilon`.  Now increment
+`epsilon_tag` in `epsilon.py` and uncomment the "CHANGED" line in the `__str__`
+method.  Rerun the second (and only the second) cell in the **Existing
+Instance** section.
+
+The LiveImport notebook output is unchanged.  While it reloaded module
+`epsilon` and rebound `Epsilon` to the new class definition, the existing
+instance was unaffected.
+
+In the autoreload notebook we have something different.
+
+```console
+an_epsilon=Epsilon<tag=1; CHANGED>
+```
+
+The `__str__` method of the existing instance was patched by `autoreload`.
+That could be good in many cases, but here it is mixed.  While the code
+changed, the state of the instance remained the same, so the result of
+converting an instance to a string does not reflect the new tag value.
+Furthermore, try uncommenting the lines referencing `self.another` and
+rerunning again.  Now the cell fails because the code references a field which
+is not defined in the instance.
+
+Patching classes with existing instances can be helpful, but existing instance
+state limits its utility and predictability.
+
+#### Step 6:
+
+This step is timing critical.  We are going to see what happens when a module
+is modified while a notebook is running multiple cells.  Get ready to edit
+`alpha.py`.  Before making any change, start running in the LiveImport notebook
+from the first **Multi-cell Run** cell down ("Run Selected Cell and All Below"
+in the standard Jupyter notebook menu).  The first cell will run for 10
+seconds.  During that 10 seconds, before the cell finishes, change `alpha_tag`
+in `alpha.py`.  Repeat this process for the autoreload notebook.
+
+Now compare the output.  In the LiveImport notebook, the `alpha_tag` values
+displayed by the first and second cells in the **Multi-cell Run** section are
+the same.  This happens because LiveImport suppresses automatic reloading
+during multi-cell runs using a grace period.  (See `liveimport.auto_sync()` in
+the API documentation.)
+
+The autoreload notebook output shows two different values for `alpha_tag`
+because the autoreload extension reloads before every cell execution.  While
+there may be cases where that's desirable, a frozen codebase during a run
+is generally best.
+
+### Other Modes
+
+Above we tested using autoreload's `explicit` mode.  What happens with `all`
+or `complete`?  The documentation for `all` says
+
+> Reload all modules (except those excluded by %aimport) every time before executing the Python code typed.
+
+That means we could have written the **Setup** cell as
+
+```python
+import sys
+import time
+common_name = "Value from notebook"
+
+%load_ext autoreload
+%autoreload all
+import alpha
+import beta
+from gamma import gamma_tag, gamma_second as gs
+import delta
+import epsilon
+```
+
+The nice thing is VSCode would now be happy.  The cost is we need negative
+`%aimport -<module>` lines for modules we don't want to automatically reload.
+All the other autoreload behavior described so far remains the same.
+
+LiveImport does not have a "automatically reload all" mode.  For one thing,
+organizing notebook code with the relevant imports placed in cells with hidden
+or non-hidden magic is not inconvenient.  More importantly, placing those
+imports in designated cells means LiveImport sees the actual Python import
+statements, and so can fully process them on reload.
+
+Mode `complete` is
+
+> Same as 2/all, but also adds any new objects in the module.
+
+That means autoreload attempts to rebind relevant notebook variables when
+reloading modules.  We mentioned that in **Step 4**, and also described it as
+inexact.  Let's explore further.
+
+#### Step 7:
+
+First, change the **Setup** section line of the autoreload notebook from
+
+```python
+%autoreload explicit
+```
+to
+```python
+%autoreload complete
+```
+
+Next, restart the LiveImport and autoreload notebook kernels.  Run all cells in
+both.
+
+Consider the **Setup** section in the notebooks and also `delta.py`.  They all
+define variables, functions, and classes called `common_int` `common_str`,
+`common_fn`, and `Common`.  The notebook definitions assign 0 to `common_int`
+and use the phrase "in notebook" in the others.  The `delta.py` definitions
+assign 99 to `common_int` and use the phrase "in delta.py" for the others.
+
+The notebooks do not import any symbols from `delta`, so naturally the lines we
+see in the **Print** output of both notebooks for these names are
+
+```console
+Notebook sees common_int=0
+Notebook sees common_str=string in notebook
+Notebook calls common_fn: in notebook
+Notebook constructs Common<class in notebook>
+```
+
+Now, increment `delta_tag` in `delta.py`, then rerun the **Print** cell
+in both notebooks.
+
+The LiveImport notebook output remains unchanged, as desired.  But
+surprisingly, we see in the autoreload notebook
+
+```console
+Notebook sees common_int=99
+Notebook sees common_str=Common string in delta.py
+Notebook calls common_fn: in notebook
+Notebook constructs Common<class in notebook>
+```
+In its attempt to rebind symbols in the notebook that are possibly imported
+from `delta`, autoreload overwrote `common_int` and `common_str` in the
+notebook just because they have the same name as variables in `delta`.
+
+LiveImport doesn't make this mistake because it parses the Python import
+statements for the modules it is to manage, and uses those statements to determine which symbols to rebind (and which to leave alone.)

--- a/comparison/alpha.py
+++ b/comparison/alpha.py
@@ -1,0 +1,10 @@
+alpha_tag = 1
+
+def alpha_fn():
+    return f"alpha_fn: tag={alpha_tag}"
+
+class Alpha:
+    def __init__(self):
+        self.tag = alpha_tag
+    def __str__(self):
+        return f"Alpha<tag={self.tag}>"

--- a/comparison/beta.py
+++ b/comparison/beta.py
@@ -1,0 +1,17 @@
+from alpha import alpha_tag, alpha_fn, Alpha
+
+beta_tag = 1
+
+def beta_fn():
+    return (f"beta_fn: tag={beta_tag}"
+            f", alpha_tag={alpha_tag}"
+            f"; calls {alpha_fn()}")
+
+class Beta:
+    def __init__(self):
+        self.tag = beta_tag
+        self.alpha_tag = alpha_tag
+    def __str__(self):
+        return (f"Beta<tag={self.tag}"
+                f", alpha_tag={self.alpha_tag}>"
+                f"; constructs {Alpha()}")

--- a/comparison/delta.py
+++ b/comparison/delta.py
@@ -1,0 +1,23 @@
+delta_tag = 1
+
+def delta_fn():
+    return f"delta_fn: tag={delta_tag}"
+
+class Delta:
+    def __init__(self):
+        self.tag = delta_tag
+    def __str__(self):
+        return f"Delta<tag={self.tag}>"
+
+
+common_int = 99
+common_str = "Common string in delta.py"
+
+def common_fn():
+    return "Common function in delta.py"
+
+def Common():
+    def __init__(self):
+        pass
+    def __str__(self):
+        return "Common class in delta.py"

--- a/comparison/epsilon.py
+++ b/comparison/epsilon.py
@@ -1,0 +1,15 @@
+epsilon_tag = 1
+
+def epsilon_fn():
+    return f"epsilon_fn: tag={epsilon_tag}"
+
+class Epsilon:
+    def __init__(self):
+        self.tag = epsilon_tag
+        #self.another = 42
+    def __str__(self):
+        result = f"Epsilon<tag={self.tag}"
+        #result += "; CHANGED"
+        #result += f"; another={self.another}"
+        result += ">"
+        return result

--- a/comparison/gamma.py
+++ b/comparison/gamma.py
@@ -1,0 +1,12 @@
+gamma_tag = 1
+gamma_second = gamma_tag
+
+def gamma_fn():
+    return f"gamma_fn: tag={gamma_tag}; second={gamma_second}"
+
+class Gamma:
+    def __init__(self):
+        self.tag = gamma_tag
+        self.second = gamma_second
+    def __str__(self):
+        return f"Gamma<tag={self.tag}; second={self.second}>"

--- a/comparison/using-autoreload.ipynb
+++ b/comparison/using-autoreload.ipynb
@@ -1,0 +1,164 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "4c02c397-d3c1-4531-9b3f-2c60c6da1fe5",
+   "metadata": {},
+   "source": [
+    "### Setup"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "0033782f-7f33-43e8-a09d-6350527d70cf",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import sys\n",
+    "import time\n",
+    "\n",
+    "common_int = 0\n",
+    "common_str = \"string in notebook\"\n",
+    "\n",
+    "def common_fn():\n",
+    "    return \"common_fn: in notebook\"\n",
+    "\n",
+    "class Common:\n",
+    "    def __init__(self):\n",
+    "        pass\n",
+    "    def __str__(self):\n",
+    "        return \"Common<class in notebook>\"\n",
+    "\n",
+    "%load_ext autoreload\n",
+    "%autoreload explicit\n",
+    "%aimport alpha\n",
+    "%aimport beta\n",
+    "from gamma import gamma_tag, gamma_second as gs, gamma_fn, Gamma\n",
+    "%aimport gamma\n",
+    "%aimport delta\n",
+    "%aimport epsilon"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "743b6ab1-beda-4c34-8de5-f16bd0494537",
+   "metadata": {},
+   "source": [
+    "### Print"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "ca0619e9-54af-4103-9d26-23228505349f",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "print(f\"Notebook sees alpha.alpha_tag={alpha.alpha_tag}\")\n",
+    "print(f\"Notebook calls alpha.{alpha.alpha_fn()}\")\n",
+    "print(f\"Notebook constructs alpha.{alpha.Alpha()}\")\n",
+    "print()\n",
+    "print(f\"Notebook sees beta.beta_tag={beta.beta_tag}\")\n",
+    "print(f\"Notebook sees beta.alpha_tag={beta.alpha_tag}\")\n",
+    "print(f\"Notebook calls beta.{beta.beta_fn()}\")\n",
+    "print(f\"Notebook constructs beta.{beta.Beta()}\")\n",
+    "print()\n",
+    "print(f\"Notebook sees gamma_tag={gamma_tag}\")\n",
+    "print(f\"Notebook sees gs={gs}\")\n",
+    "print(f\"Notebook calls gamma_fn()={gamma_fn()}\")\n",
+    "print(f\"Notebook constructs {Gamma()}\")\n",
+    "print(f\"[gamma.gamma_second={sys.modules['gamma'].__dict__['gamma_second']}]\")\n",
+    "print()\n",
+    "print(f\"Notebook sees delta.delta_tag={delta.delta_tag}\")\n",
+    "print(f\"Notebook calls delta.{delta.delta_fn()}\")\n",
+    "print(f\"Notebook constructs delta.{delta.Delta()}\")\n",
+    "print()\n",
+    "print(f\"Notebook sees common_int={common_int}\")\n",
+    "print(f\"Notebook sees common_str={common_str}\")\n",
+    "print(f\"Notebook calls {common_fn()}\")\n",
+    "print(f\"Notebook constructs {Common()}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "0376a775-88b2-483e-893b-55704f7a9b65",
+   "metadata": {},
+   "source": [
+    "### Existing Instance"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "3f268db5-258c-456d-b585-bcdaf14daec3",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "an_epsilon = epsilon.Epsilon()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "bae7ccc0-3762-48ed-a60f-d4e01a1d9959",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "print(f\"an_epsilon={an_epsilon}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "27b398b8-00b9-4fe1-87a1-8850c40fb0ce",
+   "metadata": {},
+   "source": [
+    "### Multi-cell Run"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "0545d400-8534-40a1-9165-c910983b728a",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "print(f\"alpha.alpha_tag before sleep is {alpha.alpha_tag}\")\n",
+    "print(\"Sleeping for 10 seconds...\")\n",
+    "time.sleep(10)\n",
+    "print(\"...done\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "b8f05dc8-101e-4ebf-87b9-9fd2696635b1",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "print(f\"Second cell sees alpha.alpha_tag={alpha.alpha_tag}\")"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.14.0"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/comparison/using-liveimport.ipynb
+++ b/comparison/using-liveimport.ipynb
@@ -1,0 +1,171 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "386a3b52",
+   "metadata": {},
+   "source": [
+    "### Setup"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "0033782f-7f33-43e8-a09d-6350527d70cf",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import sys\n",
+    "import time\n",
+    "import liveimport\n",
+    "liveimport.hidden_cell_magic(True)\n",
+    "\n",
+    "common_int = 0\n",
+    "common_str = \"string in notebook\"\n",
+    "\n",
+    "def common_fn():\n",
+    "    return \"common_fn: in notebook\"\n",
+    "\n",
+    "class Common:\n",
+    "    def __init__(self):\n",
+    "        pass\n",
+    "    def __str__(self):\n",
+    "        return \"Common<class in notebook>\""
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "8202d58a-fe05-473b-9ac9-00587fbdf3c8",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "#_%%liveimport --clear\n",
+    "import alpha\n",
+    "import beta\n",
+    "from gamma import gamma_tag, gamma_second as gs, gamma_fn, Gamma\n",
+    "import delta\n",
+    "import epsilon"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "d88cd8a5",
+   "metadata": {},
+   "source": [
+    "### Print"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "ca0619e9-54af-4103-9d26-23228505349f",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "print(f\"Notebook sees alpha.alpha_tag={alpha.alpha_tag}\")\n",
+    "print(f\"Notebook calls alpha.{alpha.alpha_fn()}\")\n",
+    "print(f\"Notebook constructs alpha.{alpha.Alpha()}\")\n",
+    "print()\n",
+    "print(f\"Notebook sees beta.beta_tag={beta.beta_tag}\")\n",
+    "print(f\"Notebook sees beta.alpha_tag={beta.alpha_tag}\")\n",
+    "print(f\"Notebook calls beta.{beta.beta_fn()}\")\n",
+    "print(f\"Notebook constructs beta.{beta.Beta()}\")\n",
+    "print()\n",
+    "print(f\"Notebook sees gamma_tag={gamma_tag}\")\n",
+    "print(f\"Notebook sees gs={gs}\")\n",
+    "print(f\"Notebook calls gamma_fn()={gamma_fn()}\")\n",
+    "print(f\"Notebook constructs {Gamma()}\")\n",
+    "print()\n",
+    "print(f\"Notebook sees delta.delta_tag={delta.delta_tag}\")\n",
+    "print(f\"Notebook calls delta.{delta.delta_fn()}\")\n",
+    "print(f\"Notebook constructs delta.{delta.Delta()}\")\n",
+    "print()\n",
+    "print(f\"Notebook sees common_int={common_int}\")\n",
+    "print(f\"Notebook sees common_str={common_str}\")\n",
+    "print(f\"Notebook calls {common_fn()}\")\n",
+    "print(f\"Notebook constructs {Common()}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "ea4c11a9",
+   "metadata": {},
+   "source": [
+    "### Existing Instance"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "d2fbd792",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "an_epsilon = epsilon.Epsilon()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "f4d20a77",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "print(f\"an_epsilon={an_epsilon}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "c984a031",
+   "metadata": {},
+   "source": [
+    "### Multi-cell Run"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "0545d400-8534-40a1-9165-c910983b728a",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "print(f\"alpha.alpha_tag before sleep is {alpha.alpha_tag}\")\n",
+    "print(\"Sleeping for 10 seconds...\")\n",
+    "time.sleep(10)\n",
+    "print(\"...done\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "b8f05dc8-101e-4ebf-87b9-9fd2696635b1",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "print(f\"Second cell sees alpha.alpha_tag={alpha.alpha_tag}\")"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.12.10"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/doc/comparison.rst
+++ b/doc/comparison.rst
@@ -1,0 +1,82 @@
+Comparison to Autoreload
+------------------------
+
+While the IPython autoreload extension is useful and widely known, LiveImport
+is different from autoreload in ways that may make it a better fit for many
+notebook workflows.
+
+Consistency
+~~~~~~~~~~~
+
+The overriding philosophy of LiveImport is that reloading must be a
+well-defined, deterministic operation that follows the semantics of a
+developer's import statements exactly.  It uses dependency awareness to
+maintain consistency and makes no guesses.  It does not mutate existing
+objects, and instead rebinds names to fresh definitions.
+
+Autoreload attempts to preserve existing object references by patching function
+and class definitions in place, and uses name-based heuristics for rebinding.
+It does not provide import statement equivalent semantics, and it accepts that
+partial updates and inconsistencies will occur.
+
+If your notebook includes the import
+
+.. code-block:: python
+
+    from netplot import baseline_color, learning_rate_color as lrc, plot_training
+
+LiveImport will rebind ``baseline_color``, ``lrc`` and ``plot_training`` and
+nothing else when it reloads ``netplot``.  If ``plot_training`` is a function
+and the colors are values (perhaps strings), autoreload patches
+``plot_training``, does not rebind ``baseline_color`` in its explicit mode,
+and never rebinds ``lrc`` in any mode.  Moreover, if both ``netplot`` and your
+notebook define ``trace_mode`` variables, autoreload will overwrite your
+notebook's ``trace_mode`` variable when it reloads ``netplot`` in complete
+mode.
+
+Autoreload's approach can also lead to stale references between modules.  For
+example, if ``orchestrate.py`` imports from ``netplot`` in the same way as
+above, plots created by ``orchestrate.train()`` would not use updated colors.
+In contrast, LiveImport would reload ``orchestrate`` after ``netplot`` changed
+in order to update ``orchestrate``'s references to ``netplot``.
+
+One advantage of autoreload's patching approach is that an existing class
+instance immediately reflects changes made to its methods.  While that can be
+useful, it is hard to always get right as a user, since new versions of methods
+must be made to work correctly with existing instance state.  LiveImport
+doesn't patch; existing instances keep their old method definitions.
+
+User Experience
+~~~~~~~~~~~~~~~
+
+LiveImport avoids reloading between cell executions of multi-cell runs.  That
+way, your running notebook codebase is frozen, even if you happen to modify a
+file during a run.  Autoreload checks for modified files before every cell
+execution, meaning function and class definitions can change in the middle of a
+run.
+
+LiveImport's hidden cell magic allows you to take full advantage of your IDE in
+code cells.  With autoreload, unless your IDE has special support for
+``%aimport`` line magic (Visual Studio Code does not), using autoreload's
+explicit mode makes your coding less productive.
+
+By default, LiveImport notifies you when it reloads modules by displaying
+Markdown blocks such as
+
+.. code-block:: console
+
+    Reloaded symcode modified 36 seconds ago
+    Reloaded simulator because symcode reloaded
+
+While you can disable notifications, they help avoid wasting time when
+unexpected reloads happen, or expected reloads do not.  Autoreload is
+silent.
+
+Explore
+~~~~~~~
+
+The `comparison <https://github.com/escreven/liveimport/comparison>`_ directory
+of LiveImport's GitHub repository contains small notebooks and modules along
+with a `step-by-step guide
+<https://github.com/escreven/liveimport/step-by-step.html>`_ if you would like
+to investigate these differences yourself.

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -1,15 +1,63 @@
 LiveImport
 ==========
 
-.. automodule:: liveimport
-    :no-members:
+LiveImport reliably and automatically reloads Python modules in Jupyter
+notebooks.  Unlike IPython's autoreload extension, LiveImport reloads are
+well-defined, deterministic operations that follow the semantics of a
+developer's import statements exactly.  It maintains consistency between
+modules by automatically reloading dependent modules as needed, ensuring
+up-to-date references across a notebook and its modules.
+
+LiveImport is designed for developers who interactively build Jupyter notebooks
+together with external Python code, and who want predictable reloading with
+minimal mystery.
+
+Given a cell like
+
+.. code-block:: python
+
+    %%liveimport
+    from common import *
+    from nets import ConvNet, ResidualNet as ResNet
+    import hyperparam as hp
+
+LiveImport will execute the import statements, then automatically reload
+``common``, ``nets``, or ``hyperparam`` whenever their source files change.
+When LiveImport reloads, it will rebind symbols in the notebook as described by
+the import statements.  If ``nets`` imports from ``hyperparam``, then when
+``hyperparam`` is modified, LiveImport will automatically reload ``nets`` after
+``hyperparam``.
+
+To make the cell above transparent to IDEs like Visual Studio Code, you can
+hide the cell magic:
+
+.. code-block:: python
+
+    #_%%liveimport
+    from common import *
+    from nets import ConvNet, ResidualNet as ResNet
+    import hyperparam as hp
+
+Hidden cell magic is a user experience feature tailored for modern notebook
+development.  Others include protection against reloading in the middle of
+multi-cell runs and optional reload notification.
+
+The :doc:`User Guide <userguide>` describes how to use LiveImport in notebooks,
+and the :doc:`API Reference <api>` provides more details.  If you currently use
+autoreload, you might consider the :doc:`Comparison with Autoreload
+<comparison>`.
+
+See :doc:`Installation <installation>` to get started.
+
 
 .. toctree::
     :maxdepth: 2
     :hidden:
     :caption: Contents:
 
+    userguide
     api
+    comparison
     installation
     issues
     tips

--- a/doc/tips.rst
+++ b/doc/tips.rst
@@ -2,10 +2,10 @@
 Tips
 ----
 
-While LiveImport does not require executed and registered import statements to
-be identical, the results of reloading may be surprising if they are not.
-Since the ``%%liveimport`` cell magic both executes and registers import
-statements, it naturally ensures that identity.
+While the LiveImport API does not require executed and registered import
+statements to be strictly identical, the results of reloading may be surprising
+if they are not.  Since the ``%%liveimport`` cell magic both executes and
+registers import statements, it naturally ensures that identity.
 
 If you choose to use `register()`:func: in a notebook instead of relying on
 cell magic or you are using LiveImport outside a notbook, the recommended

--- a/doc/userguide.rst
+++ b/doc/userguide.rst
@@ -1,0 +1,5 @@
+User Guide
+==========
+
+.. automodule:: liveimport
+    :no-members:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "liveimport"
-version = "1.0.3.dev0"
+version = "1.0.3"
 description = "Automatically reload modified Python modules in notebooks and scripts."
 readme = "README.md"
 authors = [{ name = "Edward Screven" }]

--- a/src/liveimport.py
+++ b/src/liveimport.py
@@ -1,4 +1,5 @@
-"""Automatically reload modified Python modules in notebooks and scripts.
+"""LiveImport automatically reloads modified Python modules in notebooks and
+scripts.
 
 Overview
 --------
@@ -34,10 +35,8 @@ LiveImport also updates imported module symbols.  For example, if you modify
 ``printmath.py``, LiveImport will reload ``printmath`` and bind ``print_math``
 and ``print_eq`` in the global namespace to the new definitions.  Similarly, if
 you update ``simulator.py``, LiveImport will create or update bindings for
-every public symbol in ``simulator`` — that is, every symbol defined in the
-module that does not start with ``_``, unless there is an ``__all__`` property
-defined for the module, in which case it acts on only those symbols, just like
-``from simulator import *``.
+every public symbol in ``simulator`` (where public means in ``__all__`` if
+present, and not starting with ``_`` otherwise.)
 
 Modules referenced by registered import statements are called tracked modules.
 The process of bringing registered imports up to date by reloading tracked
@@ -53,9 +52,9 @@ Hidden Cell Magic
 
 Unfortunately, Visual Studio Code and possibly other environments do not
 analyze magic cell content, making ``%%liveimport`` use awkward.  However,
-LiveImport includes a workaround: calling :func:`hidden_cell_magic(True)
-<hidden_cell_magic>` causes ``#_%%liveimport`` lines at the beginning of
-cells to act just like ``%%liveimport`` when the cell is run, and since
+LiveImport has a solution: calling :func:`hidden_cell_magic(True)
+<hidden_cell_magic>` causes ``#_%%liveimport`` lines at the beginning of cells
+to act just like ``%%liveimport`` when the cell is run, and since
 ``#_%%liveimport`` is a Python comment, Visual Studio Code and other
 environments do analyze the content.
 
@@ -126,7 +125,7 @@ cell below is equivalent to the previous example.
       from simulator import *
       \"\"\", clear=True)
 
-While cell magic is generally more convenient, programmatic registeration might
+While cell magic is generally more convenient, programmatic registration might
 be useful if your notebook conditionally imports modules you wish to
 automatically reload, something like
 
@@ -134,9 +133,11 @@ automatically reload, something like
 
       from packaging.version import Version
 
-      if Version(sympy.__version__) < Version("1.14"):
-          import sympyshim
-          liveimport.register(globals(),"import sympyshim")
+      if Version(sympy.__version__) < Version("1.13"):
+          from sympyshim import groups_count
+          liveimport.register(globals(),"from sympyshim import groups_count")
+      else:
+          from sympy.combinatorics.group_numbers import groups_count
 
 Managing Synchronization
 ------------------------
@@ -162,7 +163,7 @@ must use programmatic registration and explicitly syncing via
    statement in Python source that is not nested within another Python
    construct such as an ``if`` or ``try`` statement.
 """
-__version__ = "1.0.3.dev0"
+__version__ = "1.0.3"
 
 import math
 import re


### PR DESCRIPTION
Switching to a production version number, plus 
* Documentation revisions, including restructuring the top level and adding a comparison with autoreload.
* Change to op.sh so it doesn't always fetch from repos.

