### PR TITLE
Publishing version 1.1.0

### DIFF
--- a/README-check.py
+++ b/README-check.py
@@ -1,0 +1,21 @@
+#
+# Verify README.md is a deployable state.
+#
+# PyPI incorporates the README into the pypi.org liveimport package description
+# page as-is.  It doesn't correct relative GitHub links, so links in README.md
+# must be absolute.
+#
+# op.sh runs this script before declaring a release or deploying the
+# [Test]PyPI.
+#
+
+import re
+import sys
+
+link_re = re.compile(r"]\(\s*([^\s]+)\s*\)")
+
+for link in link_re.findall(open("README.md").read()):
+    if not link.startswith("https://"):
+        print(f"README.md may contain link {link}",file=sys.stderr)
+        print("Only absolute https:// links should be used")
+        sys.exit(1)

--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ development.  Others include protection against reloading in the middle of
 multi-cell runs and optional reload notification.
 
 If you currently use autoreload, you might consider [comparing LiveImport
-to autoreload](comparison/Comparison.md).
+to autoreload](https://github.com/escreven/liveimport/blob/main/comparison/Comparison.md).
 
 ## Documentation
 

--- a/comparison/Comparison.md
+++ b/comparison/Comparison.md
@@ -26,11 +26,13 @@ from netplot import baseline_color, learning_rate_color as lrc, plot_training
 LiveImport will rebind ``baseline_color``, ``lrc`` and ``plot_training`` and
 nothing else when it reloads ``netplot``.  If ``plot_training`` is a function
 and the colors are values (perhaps strings), autoreload patches
-``plot_training``, does not rebind ``baseline_color`` in its explicit mode,
-and never rebinds ``lrc`` in any mode.  Moreover, if both ``netplot`` and your
-notebook define ``trace_mode`` variables, autoreload will overwrite your
-notebook's ``trace_mode`` variable when it reloads ``netplot`` in complete
-mode.
+``plot_training``, does not rebind ``baseline_color`` in its explicit mode, and
+never rebinds ``lrc`` in any mode.
+
+Moreover, if both ``netplot`` and your notebook define ``trace_mode``
+variables, autoreload in complete mode will overwrite your notebook's
+``trace_mode`` variable when it reloads ``netplot``, even though you haven't
+imported ``trace_mode`` from ``netplot``.
 
 Autoreload's approach can also lead to stale references between modules.  For
 example, if ``orchestrate.py`` imports from ``netplot`` in the same way as
@@ -40,7 +42,7 @@ in order to update ``orchestrate``'s references to ``netplot``.
 
 One advantage of autoreload's patching approach is that an existing class
 instance immediately reflects changes made to its methods.  While that can be
-useful, it is hard to always get right as a user, since new versions of methods
+useful, it's hard to always get right as a user, since new versions of methods
 must be made to work correctly with existing instance state.  LiveImport
 doesn't patch; existing instances keep their old method definitions.
 

--- a/comparison/README.md
+++ b/comparison/README.md
@@ -138,8 +138,8 @@ have to do that: LiveImport supports every legal Python import statement,
 including relative imports.
 
 Let's test the autoreload workaround.  Increment `gamma_tag` in `gamma.py`.
-That will also update a variable `gamma_second` in `gamma.py`.  Recall the
-relevant import statement
+That will also update a variable `gamma_second` in `gamma.py`.  The
+relevant import statement is
 
 ```python
 from gamma import gamma_tag, gamma_second as gs, gamma_fn, Gamma

--- a/comparison/using-liveimport.ipynb
+++ b/comparison/using-liveimport.ipynb
@@ -18,7 +18,6 @@
     "import sys\n",
     "import time\n",
     "import liveimport\n",
-    "liveimport.hidden_cell_magic(True)\n",
     "\n",
     "common_int = 0\n",
     "common_str = \"string in notebook\"\n",

--- a/doc/comparison.rst
+++ b/doc/comparison.rst
@@ -28,11 +28,13 @@ If your notebook includes the import
 LiveImport will rebind ``baseline_color``, ``lrc`` and ``plot_training`` and
 nothing else when it reloads ``netplot``.  If ``plot_training`` is a function
 and the colors are values (perhaps strings), autoreload patches
-``plot_training``, does not rebind ``baseline_color`` in its explicit mode,
-and never rebinds ``lrc`` in any mode.  Moreover, if both ``netplot`` and your
-notebook define ``trace_mode`` variables, autoreload will overwrite your
-notebook's ``trace_mode`` variable when it reloads ``netplot`` in complete
-mode.
+``plot_training``, does not rebind ``baseline_color`` in its explicit mode, and
+never rebinds ``lrc`` in any mode.
+
+Moreover, if both ``netplot`` and your notebook define ``trace_mode``
+variables, autoreload in complete mode will overwrite your notebook's
+``trace_mode`` variable when it reloads ``netplot``, even though you haven't
+imported ``trace_mode`` from ``netplot``.
 
 Autoreload's approach can also lead to stale references between modules.  For
 example, if ``orchestrate.py`` imports from ``netplot`` in the same way as
@@ -42,7 +44,7 @@ in order to update ``orchestrate``'s references to ``netplot``.
 
 One advantage of autoreload's patching approach is that an existing class
 instance immediately reflects changes made to its methods.  While that can be
-useful, it is hard to always get right as a user, since new versions of methods
+useful, it's hard to always get right as a user, since new versions of methods
 must be made to work correctly with existing instance state.  LiveImport
 doesn't patch; existing instances keep their old method definitions.
 

--- a/doc/tips.rst
+++ b/doc/tips.rst
@@ -14,23 +14,18 @@ immediately by a `register()`:func: call with the same import statement text
 written as a multiline string.  That way maintaining identical executed and
 registered import statements is simple.
 
-When using either ``%%liveimport`` magic or `register()`:func: calls in a
-notebook, it's best if the first use in the notebook includes option
-``--clear`` or ``clear=True`` respectively.  If it does, rerunning the notebook
-makes LiveImport registrations consistent with what appears in the notebook.
-
 Modules sometimes take action when they load that should be performed
 differently or not at all when they reload.  Here is one approach:
 
     .. code:: python
 
-        try:
-            _did_initial_load    #type:ignore
-            print("Reloading module")
-        except NameError:
+        if "_did_initial_load" not in globals():
             _did_initial_load = True
             print("First load of module")
+        else:
+            print("Reloading module")
 
 The code above should be at the top level of your module.  Because
-``_did_initial_load`` is undefined on the first load, the exception handling
-code runs.  On reloads, the ``try`` primary path runs normally.
+``_did_initial_load`` is undefined on the first load, the ``if`` condition is
+true, so the ``if`` body statements run.  On reloads, the ``if`` condition is
+false, so the ``else`` body runs.

--- a/doc/userguide.rst
+++ b/doc/userguide.rst
@@ -1,5 +1,261 @@
 User Guide
 ==========
 
-.. automodule:: liveimport
-    :no-members:
+Overview
+--------
+
+LiveImport eliminates the need to restart a notebook's Python kernel to
+reimport code under development in external files.  Suppose you are maintaining
+symbolic math code in ``symcode.py``, LaTeX formatting utilities in
+``printmath.py``, and a simulator in ``simulator.py``.  In the first cell of a
+notebook, you might write
+
+  .. code:: python
+
+      import liveimport
+      import numpy as np
+      import matplotlib.pyplot as plot
+
+and in the second
+
+  .. code:: python
+
+      %%liveimport
+      import symcode
+      from printmath import print_math, print_equations as print_eq
+      from simulator import *
+
+When the ``%%liveimport`` cell is run, LiveImport executes and registers the
+import statements.  Thereafter, whenever you run cells, LiveImport will reload
+any of ``symcode``, ``printmath``, and ``simulator`` that have changed since
+registration or their last reload.  LiveImport deems a module changed when its
+source file modification time changes.
+
+LiveImport also updates imported module symbols.  For example, if you modify
+``printmath.py``, LiveImport will reload ``printmath`` and bind ``print_math``
+and ``print_eq`` in the global namespace to the new definitions.  Similarly, if
+you update ``simulator.py``, LiveImport will create or update bindings for
+every public symbol in ``simulator`` (where public means in ``__all__`` if
+present, and not starting with ``_`` otherwise.)
+
+Importantly, LiveImport *only* updates symbols in the same way the original
+import statements would.  If your notebook and ``symcode`` both happened to
+define a variable ``gamma``, reloading ``symcode`` would not overwrite your
+notebook's value of ``gamma``.  Though it isn't implemented this way, you can
+think of LiveImport as re-executing the registered import statements associated
+with a reloaded module.
+
+Modules referenced by registered import statements are called tracked modules.
+The process of bringing registered imports up to date by reloading tracked
+modules and updating symbols is called syncing.
+
+Hidden Cell Magic
+-----------------
+
+As it turns out, Visual Studio Code and possibly other environments do not
+analyze magic cell content, making ``%%liveimport`` use awkward.  However,
+LiveImport has a simple solution: ``#_%%liveimport`` lines at the beginning of
+cells act just like ``%%liveimport`` when the cell is run, and since
+``#_%%liveimport`` is a Python comment, Visual Studio Code and other
+environments do analyze the content.
+
+To use hidden cell magic with the example above, replace the second cell with
+
+  .. code:: python
+
+      #_%%liveimport
+      import symcode
+      from printmath import print_math, print_equations as print_eq
+      from simulator import *
+
+If you prefer, you can disable hidden cell magic by calling
+:func:`hidden_cell_magic(enabled=False) <hidden_cell_magic>`.
+
+Dependency Analysis
+-------------------
+
+LiveImport analyzes top-level import dependencies between tracked modules to
+ensure reloading is consistent with those dependencies and to prevent stale
+references between modules.
+
+Suppose ``simulator`` imports ``x`` from ``symcode`` where ``x`` is defined in
+``symcode.py`` as
+
+  .. code:: python
+
+     x = sympy.Symbol("x", positive=True)
+
+If you realize the assumption about symbolic variable ``x`` being positive is
+unwarranted and change the line to
+
+  .. code:: python
+
+     x = sympy.Symbol("x")
+
+``simulator`` must be reloaded — and reloaded after ``symcode`` — otherwise it
+would still refer to the old definition of ``x`` with the assumption of
+positivity.  ``simulator``'s evaluations involving ``x`` would be incorrect.
+
+Fortunately, LiveImport's dependency aware reloading does exactly that.  When
+you modify ``symcode.py``, LiveImport reloads ``simulator`` after it reloads
+``symcode`` even if ``simulator.py`` has not changed.  If you do modify both,
+LiveImport takes care to reload ``symcode`` first.  No stale references are
+created.
+
+Registration Details
+--------------------
+
+While ``%%liveimport`` cells often contain only import statements, they can
+actually contain any valid Python code.  For example,
+
+  .. code:: python
+
+      #_%%liveimport
+      from models import ConvNet
+      from orchestrate import *  # Includes default_learning_rate
+      print(f"Default learning rate is {default_learning_rate}")
+
+When a ``%%liveimport`` cell is run, LiveImport first executes the Python
+source.  If execution completes without an exception, LiveImport extracts from
+the cell the top-level import statements.  It then registers those statements
+and begins tracking the related modules, if they are not already tracked.
+
+The only restriction LiveImport imposes on import statements is the relevant
+modules must have source files.  Other than that, the statements can overlap,
+they can repeat, they can be any kind of import statement that is legal to use
+in a notebook.  For example, the following cell is perfectly fine.
+
+  .. code:: python
+
+      #_%%liveimport
+      from symcode import x, hermite_poly
+      from symcode import x, lagrange_poly
+      from symcode import lagrange_poly as lp
+      from symcode import *
+      import symcode
+      import symcode as sc
+
+Normally, ``%%liveimport`` cells are additive.  Top-level import statements are
+registered without removing prior registrations.  The ``%%liveimport`` cell
+magic's one optional argument ``--clear`` (or the short form, ``-c``) changes
+that — it causes LiveImport to discard all prior import registrations when the
+cell is run.
+
+Best Practice
+-------------
+
+The recommended best practice is for notebooks to have one ``%%liveimport``
+cell, and that cell should include option ``--clear``.  In the case of the
+**Overview** example, if you are hiding cell magic, that one cell would be
+
+  .. code:: python
+
+      #_%%liveimport --clear
+      import symcode
+      from printmath import print_math, print_equations as print_eq
+      from simulator import *
+
+This way, if you want to stop tracking modifications to ``symcode.py``, you can
+simply delete ``import symcode`` and rerun the containing cell.  If you do have
+multiple ``%%liveimport`` cells, then it's best if the first (and only the
+first) uses option ``--clear``.
+
+Reload Reports
+--------------
+
+By default, LiveImport displays Markdown console blocks to report when it
+automatically reloads modules in a notebook, something like
+
+  .. code:: console
+
+      Reloaded symcode modified 18 seconds ago
+      Reloaded simulator because symcode reloaded
+
+You can disable these reports by calling
+:func:`auto_sync(report=False)<auto_sync>`.
+
+Top-Level Imports
+-----------------
+
+A top-level import is any ``import ...`` or ``from ... import ...`` statement
+in Python source that is not nested within another Python construct such as an
+``if`` or ``try`` statement.
+
+  .. code:: python
+
+      import colors
+      if _need_debug:
+          from debug import *
+      def report(data):
+          from formatutil import layout
+          generate_table(layout,data)
+      from common import epilogue
+
+In the code above, ``import colors`` and ``from common import epilogue`` are
+the only two top-level import statements.  As stated in the preceding sections,
+LiveImport only processes top-level imports in Python source.  That affects
+both registration through ``%%liveimport`` cells and module dependency
+tracking.
+
+If it essential for your application, it is possible to use the API to
+implement conditional imports that are registered.  There is an example in the
+next section.
+
+Programmatic Registration
+-------------------------
+
+As an alternative to ``%%liveimport`` cell magic, you can register import
+statements by calling :func:`register()<register>`.  Unlike ``%%liveimport``
+cell magic, :func:`register()` does not execute the import statements it
+registers, so you must execute them before calling :func:`register()`.  The
+cell below is equivalent to the **Overview** example.
+
+  .. code:: python
+
+      import liveimport
+      import numpy as np
+      import matplotlib.pyplot as plot
+
+      import symcode
+      from printmath import print_math, print_equations as print_eq
+      from simulator import *
+
+      liveimport.register(globals(),"""
+      import symcode
+      from printmath import print_math, print_equations as print_eq
+      from simulator import *
+      """, clear=True)
+
+While cell magic is far more convenient, programmatic registration might be
+useful if your notebook conditionally imports modules you wish to automatically
+reload, something like
+
+  .. code:: python
+
+      from packaging.version import Version
+
+      if Version(sympy.__version__) < Version("1.13"):
+          from sympyshim import groups_count
+          liveimport.register(globals(),"from sympyshim import groups_count")
+      else:
+          from sympy.combinatorics.group_numbers import groups_count
+
+Managing Synchronization
+------------------------
+
+In order to avoid reloading modules between cell executions of a multi-cell run
+(such as when running all cells), LiveImport suppresses module modification
+checks for a grace period after each cell execution. The default grace period
+is one second.  You can change the grace period by calling
+:func:`auto_sync(grace=...) <auto_sync>`.
+
+You can also disable automatic syncing altogether by calling
+:func:`auto_sync(enabled=False) <auto_sync>` and rely on explicit syncing
+through calls to :func:`sync()` instead.
+
+Outside of Notebooks
+--------------------
+
+You can use LiveImport outside of notebook environments, but in that case, you
+must use programmatic registration and explicitly sync via
+:func:`register()` and :func:`sync()`.

--- a/op.sh
+++ b/op.sh
@@ -184,6 +184,15 @@ function require_git_clean {
 }
 
 #
+# Require the top-level README.md to be in a deployable state.  For now that
+# just means only absolute links.
+#
+
+function require_deployable_README {
+    $PYTHON README-check.py || fail "README.md is not deployable"
+}
+
+#
 # Run tests with coverage measurement and report the results.
 #
 
@@ -289,6 +298,7 @@ function declare_release {
     require_not_released "$version"
     require_good_build "$version"
     require_git_clean $PUBLIC/main
+    require_deployable_README
 
     tag="v$version"
     git tag -a "$tag" -m "Release $version"
@@ -316,6 +326,7 @@ upload_dist() {
     require_good_build "$version"
     require_released "$version"
     require_git_clean "v$version"
+    require_deployable_README
 
     local confirm
     echo
@@ -347,6 +358,7 @@ usage() {
     echo "    check-version       Verify and print consistent project version"
     echo "    check-dist          Verify the distribution files"
     echo "    check-clean-main    Verify local repo is on clean main branch"
+    echo "    check-README        Verify README.md is deployable"
     echo "    declare-release     Tag current clean main branch as a release"
     echo "    deploy-to-testpypi  Upload distribution files to TestPyPI"
     echo "    deploy-to-pypi      Upload distribution files to PyPI"
@@ -403,6 +415,9 @@ function act {
             ;;
         check-clean-main)
             require_git_clean $PUBLIC/main
+            ;;
+        check-README)
+            require_deployable_README
             ;;
         declare-release)
             declare_release

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "liveimport"
-version = "1.0.3"
+version = "1.1.0"
 description = "Automatically reload modified Python modules in notebooks and scripts."
 readme = "README.md"
 authors = [{ name = "Edward Screven" }]

--- a/test/notebook.ipynb
+++ b/test/notebook.ipynb
@@ -18,15 +18,15 @@
     "|`#@ presleep` *seconds* | Sleep for *seconds* before executing cell |\n",
     "\n",
     "A scripted test fails if a code cell does not have an \"OK\" Markdown output\n",
-    "unless that cell has a `#@ missingok` directive.  `#@ reload` and `@# error`\n",
-    "declarations are exclusive; the tester both requires those reloads and errors\n",
-    "and permits no others.  Furthermore, the order of reloads and errors in the\n",
-    "output must match the order of their respective declarations.\n",
+    "unless that cell has a `#@ missingok` directive.  `#@ reload` and `#@ error`\n",
+    "declarations are exclusive in the sense that the tester requires the listed\n",
+    "reloads and errors and permits no others.  Furthermore, the order of reloads\n",
+    "and errors in the output must match the order of their respective declarations.\n",
     "\n",
     "Manual testing procedure:\n",
     "\n",
     "1. Clear all cell output\n",
-    "2. Restart the server\n",
+    "2. Restart the kernel\n",
     "3. Run all cells\n",
     "\n",
     "The notebook is designed to work without #2, but it is probably best for\n",
@@ -400,7 +400,6 @@
     "\n",
     "liveimport.register(globals(),\"\",clear=True)\n",
     "liveimport.auto_sync(enabled=True,grace=0.0)\n",
-    "liveimport.hidden_cell_magic(enabled=False)\n",
     "body_ran = False\n",
     "ok()"
    ]
@@ -562,9 +561,65 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "assert not is_registered('mod3')\n",
+    "body_ran = False\n",
+    "ok()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
     "#_%%liveimport\n",
     "# pyright: reportMissingImports=false\n",
     "from mod3 import *\n",
+    "body_ran = True\n",
+    "ok()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "#\n",
+    "# Verify hidden cell magic is enabled by default.\n",
+    "#\n",
+    "\n",
+    "assert is_registered('mod3')\n",
+    "assert body_ran\n",
+    "liveimport.register(globals(),\"\",clear=True)\n",
+    "ok()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "#\n",
+    "# Disable hidden cell magic\n",
+    "#\n",
+    "\n",
+    "liveimport.hidden_cell_magic(False)\n",
+    "body_ran = False\n",
+    "ok()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "#_%%liveimport\n",
+    "# pyright: reportMissingImports=false\n",
+    "from mod3 import *\n",
+    "body_ran = True\n",
     "ok()"
    ]
   },
@@ -579,6 +634,7 @@
     "#\n",
     "\n",
     "assert not is_registered('mod3')\n",
+    "assert body_ran\n",
     "ok()"
    ]
   },
@@ -617,7 +673,7 @@
    "outputs": [],
    "source": [
     "#\n",
-    "# Verify hidden cell magic is enabled.\n",
+    "# Verify hidden cell magic is re-enabled.\n",
     "#\n",
     "assert body_ran\n",
     "assert is_registered('mod3')\n",
@@ -972,7 +1028,7 @@
     "#\n",
     "\n",
     "liveimport.auto_sync(enabled=True, grace=1.0, report=True)\n",
-    "liveimport.hidden_cell_magic(enabled=False)\n",
+    "liveimport.hidden_cell_magic(enabled=True)\n",
     "ok()"
    ]
   }
@@ -993,7 +1049,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.12.7"
+   "version": "3.12.10"
   },
   "orig_nbformat": 4
  },


### PR DESCRIPTION
Hidden cell magic is now enabled by default.

The user guide page of the documentation is now more extensive.  The content now exists directly in userguide.rst and is no longer extracted from liveimport.py.

There is now a pre-deployment check for relative links in README.md.  Hopefully, we can avoid creating dead links on the pypi.org page again.
